### PR TITLE
Upgrades Twilio Python library to 6.6.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.10.1
-twilio~=6.0.0
+twilio~=6.6.0
 fake-factory==0.5.3


### PR DESCRIPTION
I was building off of the quickstart app and got bit by a bug like this one: https://github.com/twilio/twilio-python/issues/283

`6.1.1` did not fix my issue, but `6.6.2` did.

To be clear, the quickstart works _as is_. Thanks!